### PR TITLE
added 'make DESTDIR=...' capability

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -54,14 +54,14 @@ OPTIM		=	@OPTIM@
 # Directories...
 #
 
+prefix		=	$(DESTDIR)@prefix@
+exec_prefix	=	$(DESTDIR)@exec_prefix@
 bindir		=	@bindir@
-datadir		=	@datadir@
-datarootdir	=	@datarootdir@
+datadir		=	$(DESTDIR)@datadir@
+datarootdir	=	$(DESTDIR)@datarootdir@
 docdir		=	@docdir@
-exec_prefix	=	@exec_prefix@
 mandir		=	@mandir@
-prefix		=	@prefix@
-libdir		=	@libdir@
+libdir		=	$(DESTDIR)@libdir@
 srcdir		=	@srcdir@
 
 VPATH		=	$(srcdir)


### PR DESCRIPTION
It should be possible to install EPM in a custom path using 
`make DESTDIR=<path> install`

This fix in Makefile.in should take care of that.