### PR TITLE
Fix installation by copying README.md instead of README

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -198,8 +198,8 @@ install: all @INSTALL_GUIS@ @INSTALL_OSX@
 	-$(MKDIR) $(docdir)
 	$(RM) $(docdir)/COPYING
 	$(CP) $(srcdir)/COPYING $(docdir)
-	$(RM) $(docdir)/README
-	$(CP) $(srcdir)/README $(docdir)
+	$(RM) $(docdir)/README.md
+	$(CP) $(srcdir)/README.md $(docdir)
 	$(RM) $(docdir)/epm-book.html
 	$(CP) $(srcdir)/doc/epm-book.html $(docdir)
 


### PR DESCRIPTION
When trying to update epm from 4.2 to 4.4 in NixOS/nixpkgs I stumbled upon this error

```
/nix/store/4niqvyc79gqiwzpycj8ab6wzxr3l13kp-coreutils-8.28/bin/cp: cannot stat './README': No such file or directory
```

Unless I'm missing something, you want to copy README.md instead of README.