### PR TITLE
FIX: GH-62: Escape $ sign with $$ instead of \$

### DIFF
--- a/qprintf.c
+++ b/qprintf.c
@@ -173,9 +173,14 @@ qprintf(FILE       *fp,		/* I - File to write to */
 
             for (i = slen; i > 0; i --, s ++, bytes ++)
 	    {
-	      if (strchr("`~#$%^&*()[{]}\\|;\'\"<>? ", *s))
+	      if (strchr("`~#%^&*()[{]}\\|;\'\"<>? ", *s))
 	      {
 	        putc('\\', fp);
+		bytes ++;
+	      }
+	      if (strchr("$", *s))
+	      {
+	        putc('$', fp);
 		bytes ++;
 	      }
 


### PR DESCRIPTION
Fix #62:
Escape `$` with `$$` instead of `\$` in qprintf.