### PR TITLE
deb: Fix syntax for dependency with min and max version

### DIFF
--- a/deb.c
+++ b/deb.c
@@ -278,7 +278,7 @@ make_subpackage(const char     *prodname,
 	  else
 	  {
 	    if (d->vernumber[1] < INT_MAX)
-	      fprintf(fp, " (>= %s, <= %s)", d->version[0], d->version[1]);
+	      fprintf(fp, " (>= %s), %s (<= %s)", d->version[0], d->product, d->version[1]);
 	    else
 	      fprintf(fp, " (>= %s)", d->version[0]);
 	  }


### PR DESCRIPTION
Versioned dependencies where both a minimum and maximum version
are present need to be specified as follows in Debian packages:

    <dependency_type>: <packagename> (>= <min_version>), <packagename> (<= <max_version>)

Currently, using versioned dependencies with both a minimum and a maximum version lead to an error when trying to create a Debian package.

Example list file:

    %product Kung Foo Firewall
    %copyright 1999-2005 by Foo Industries, All Rights Reserved.
    %vendor Foo Industries
    %license COPYING
    %readme README
    %description Kung Foo firewall software for your firewall.
    %version 1.2.3p4 1020304
    %requires foobar 1.0 2.0

    f 755 root root /tmp/dummy dummy

Resulting error message when trying to create a Debian package:

    $ fakeroot epm -f deb spec
    Packaging failed!

This pull request fixes this by introducing the correct syntax when writing the directive to the Debian control file.